### PR TITLE
Fix LocalCache embedding reload handling

### DIFF
--- a/autogpt/memory/local.py
+++ b/autogpt/memory/local.py
@@ -46,6 +46,11 @@ class LocalCache(MemoryProviderSingleton):
                         f.write(file_content)
 
                     loaded = orjson.loads(file_content)
+                    embeddings = loaded.get("embeddings")
+                    if embeddings is not None:
+                        loaded["embeddings"] = np.array(
+                            embeddings, dtype=np.float32
+                        )
                     self.data = CacheContent(**loaded)
             except orjson.JSONDecodeError:
                 print(f"Error: The file '{self.filename}' is not in JSON format.")


### PR DESCRIPTION
## Summary
- convert persisted cache embeddings back into numpy arrays before instantiating `CacheContent`

## Testing
- pytest tests/local_cache_test.py *(fails: tests/local_cache_test.py: NameError: name 'unittest' is not defined)*
- PYTHONPATH=. pytest tests/integration/memory_tests.py *(fails: requires OpenAI API key)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb5632590832e9ba75fb67aaa5c35